### PR TITLE
Update deployment with a liveness check

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -50,6 +50,13 @@ spec:
             - containerPort: 5053
               name: cloudflared-udp
               protocol: UDP
+          livenessProbe:
+            exec:
+              command:
+              - "/usr/bin/nc"
+              - "-uzvw3"
+              - "localhost"
+              - "5053"
         {{- end }}
         - name: {{ .Chart.Name }}
           env:


### PR DESCRIPTION
Cloudflared container kept getting killed by kernel OOM Killer but container was never recreated. I added a simple nc for the port and if kernel kills the process again it should mark it as failed and recreate it 🤞 